### PR TITLE
Fix underlines in Windows console mode.

### DIFF
--- a/console_win.go
+++ b/console_win.go
@@ -231,7 +231,7 @@ func (s *cScreen) Init() error {
 	// 24-bit color is opt-in for now, because we can't figure out
 	// to make it work consistently.
 	if s.truecolor {
-		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut)
+		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut | modeUnderline)
 		var om uint32
 		s.getOutMode(&om)
 		if om&modeVtOutput == modeVtOutput {
@@ -334,7 +334,7 @@ func (s *cScreen) engage() error {
 	s.enableMouse(s.mouseEnabled)
 
 	if s.vten {
-		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut)
+		s.setOutMode(modeVtOutput | modeNoAutoNL | modeCookedOut | modeUnderline)
 	} else {
 		s.setOutMode(0)
 	}
@@ -1213,6 +1213,8 @@ const (
 	modeCookedOut uint32 = 0x0001
 	modeVtOutput         = 0x0004
 	modeNoAutoNL         = 0x0008
+	// ENABLE_LVB_GRID_WORLDWIDE, needed to make underlines actually work.
+	modeUnderline        = 0x0010
 	// modeWrapEOL          = 0x0002
 )
 


### PR DESCRIPTION
Currently underlines do not work in pure Windows console mode without VT escapes. This is because the ENABLE_LVB_GRID_WORLDWIDE flag is needed on initialization to enable them. I checked that underlines do appear in the classic windows console with this patch enabled.